### PR TITLE
T4 SPI1 typo

### DIFF
--- a/src/fastspi.h
+++ b/src/fastspi.h
@@ -84,7 +84,7 @@ template<uint32_t SPI_SPEED>
 class SPIOutput<SPI_DATA, SPI_CLOCK, SPI_SPEED> : public Teesy4HardwareSPIOutput<SPI_DATA, SPI_CLOCK, SPI_SPEED, SPI, 0> {};
 
 template<uint32_t SPI_SPEED>
-class SPIOutput<SPI1_DATA, SPI_CLOCK, SPI_SPEED> : public Teesy4HardwareSPIOutput<SPI1_DATA, SPI1_CLOCK, SPI_SPEED, SPI1, 1> {};
+class SPIOutput<SPI1_DATA, SPI1_CLOCK, SPI_SPEED> : public Teesy4HardwareSPIOutput<SPI1_DATA, SPI1_CLOCK, SPI_SPEED, SPI1, 1> {};
 
 template<uint32_t SPI_SPEED>
 class SPIOutput<SPI2_DATA, SPI2_CLOCK, SPI_SPEED> : public Teesy4HardwareSPIOutput<SPI2_DATA, SPI2_CLOCK, SPI_SPEED, SPI2, 2> {};


### PR DESCRIPTION
Note: As far as I can tell TD 1.57B3 is going off of your fork, which is 60+ changes
behind FastLED/FastLED main fork.

This fixes using SPI1 with FastLED, was a typo where it did not have table correct